### PR TITLE
Fix EA Desktop arg patching and improve mod data reliability

### DIFF
--- a/Launcher/src/renderer/Renderer.cpp
+++ b/Launcher/src/renderer/Renderer.cpp
@@ -1,6 +1,7 @@
 #include "Renderer.hpp"
 #include "Ui.hpp"
 #include "Config.hpp"
+#include "Utils.hpp"
 
 ID3D11Device* Renderer::pd3dDevice = nullptr;
 ID3D11DeviceContext* Renderer::pd3dDeviceContext = nullptr;
@@ -167,6 +168,8 @@ void Renderer::Run()
         ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
         pSwapChain->Present(1, 0);
     }
+
+    Utils::Process::RestoreEAArgs();
 
     ImGui_ImplDX11_Shutdown();
     ImGui_ImplWin32_Shutdown();

--- a/Launcher/src/ui/Ui.cpp
+++ b/Launcher/src/ui/Ui.cpp
@@ -270,8 +270,10 @@ static void drawLauncherTab(HWND hwnd, float dpiScale) {
 				modDataPath = "ModData/" + currentGame.moddata_selected;
 			}
 
-			Utils::Process::PatchEAArgs(args);
-			auto lr = Utils::Process::LaunchAndInject(currentGame.game_path, args, isGW1, "level_loader.dll", modDataPath);
+			bool isGW2 = (g_config.game_selected == "GW2");
+			
+			Utils::Process::PatchEAArgs(args, isGW2);
+			auto lr = Utils::Process::LaunchAndInject(currentGame.game_path, args, "level_loader.dll", modDataPath, isGW2);
 
 			if (!lr.ok) {
 				showStatus("Failed to launch: " + lr.error, true);

--- a/Launcher/src/utils/Utils.cpp
+++ b/Launcher/src/utils/Utils.cpp
@@ -2,6 +2,8 @@
 
 #include <fstream> 
 #include <filesystem>
+#include <map>
+#include <algorithm>
 #include <shlobj.h>
 #include <shellapi.h>
 #include <shlwapi.h>
@@ -101,7 +103,7 @@ namespace Utils {
 
 			if (!game.custom_args.empty()) argList.push_back(game.custom_args);
 
-				if (!cfg.username.empty()) argList.push_back("-name " + cfg.username);
+			if (!cfg.username.empty()) argList.push_back("-name " + cfg.username);
 			if (!cfg.server_ip.empty()) argList.push_back("-Client.ServerIp " + cfg.server_ip);
 			if (!cfg.password.empty()) argList.push_back("-Server.ServerPassword " + cfg.password);
 
@@ -114,8 +116,15 @@ namespace Utils {
 			return args;
 		}
 
-		void PatchEAArgs(const std::string& args) {
+		static std::map<std::string, std::string> originalArgs;
+
+		void PatchEAArgs(const std::string& args, bool isGW2) {
 			fs::path eaDir = fs::path(getenv("LOCALAPPDATA")) / "Electronic Arts" / "EA Desktop";
+
+			std::string cleanedArgs = args;
+			if (!cleanedArgs.empty()) {
+				cleanedArgs.erase(std::remove(cleanedArgs.begin(), cleanedArgs.end(), '\"'), cleanedArgs.end());
+			}
 
 			for (const auto& entry : fs::directory_iterator(eaDir)) {
 				if (entry.is_regular_file() && entry.path().extension() == ".ini") {
@@ -129,7 +138,10 @@ namespace Utils {
 						if (line.rfind("user.gamecommandline.ofb-east:", 0) == 0) {
 							auto pos = line.find('=');
 							if (pos != std::string::npos) {
-								line = line.substr(0, pos + 1) + args;
+								if (originalArgs.find(entry.path().string()) == originalArgs.end()) {
+									originalArgs[entry.path().string()] = line.substr(pos + 1);
+								}
+								line = line.substr(0, pos + 1) + cleanedArgs;
 								modified = true;
 							}
 						}
@@ -143,6 +155,34 @@ namespace Utils {
 					}
 				}
 			}
+		}
+
+		void RestoreEAArgs() {
+			for (const auto& [filePath, originalValue] : originalArgs) {
+				std::ifstream in(filePath);
+				if (!in) continue;
+
+				std::string line, output;
+				bool modified = false;
+
+				while (std::getline(in, line)) {
+					if (line.rfind("user.gamecommandline.ofb-east:", 0) == 0) {
+						auto pos = line.find('=');
+						if (pos != std::string::npos) {
+							line = line.substr(0, pos + 1) + originalValue;
+							modified = true;
+						}
+					}
+					output += line + "\n";
+				}
+				in.close();
+
+				if (modified) {
+					std::ofstream out(filePath, std::ios::trunc);
+					out << output;
+				}
+			}
+			originalArgs.clear();
 		}
 
 		bool InjectDLL(DWORD processId, const std::string& dllPath) {
@@ -217,13 +257,16 @@ namespace Utils {
 
 		LaunchResult LaunchAndInject(const std::string& exePath,
 			const std::string& args,
-			bool injectDLL,
 			const std::string& dllName,
-			const std::string& modDataPath)
+			const std::string& modDataPath,
+			bool isGW2)
 		{
 			KillProcessByName("EADesktop.exe");
 			KillProcessByName("Origin.exe");
-			KillProcessByName("steam.exe");
+			
+			if (isGW2) {
+				KillProcessByName("steam.exe");
+			}
 
 			LaunchResult lr;
 			STARTUPINFOA si = { sizeof(si) };
@@ -282,7 +325,7 @@ namespace Utils {
 			lr.ok = true;
 			lr.pi = pi;
 
-			if (injectDLL) {
+			if (!isGW2) {
 				fs::path dllPath = fs::path(exePath).parent_path() / dllName;
 				if (!fs::exists(dllPath)) {
 					lr.error = dllName + " not found next to the game exe.";

--- a/Launcher/src/utils/Utils.hpp
+++ b/Launcher/src/utils/Utils.hpp
@@ -29,9 +29,10 @@ namespace Utils {
 		};
 
 		std::string BuildArgs(const Config& cfg);
-		void PatchEAArgs(const std::string& args);
+		void PatchEAArgs(const std::string& args, bool isGW2);
+		void RestoreEAArgs();
 
-		LaunchResult LaunchAndInject(const std::string& exePath, const std::string& args, bool injectDLL, const std::string& dllName = "level_loader.dll", const std::string& modDataPath = "");
+		LaunchResult LaunchAndInject(const std::string& exePath, const std::string& args, const std::string& dllName = "level_loader.dll", const std::string& modDataPath = "", bool isGW2 = false);
 		bool InjectDLL(DWORD processId, const std::string& dllPath);
 	}
 


### PR DESCRIPTION
- The `PatchEAArgs` function now saves the original EA Desktop `.ini` argument values and removes quotes from arguments, allowing for later restoration. A new `RestoreEAArgs` function is called after launching to revert changes, preventing persistent side effects on the user's system. [[1]](diffhunk://#diff-95932622b19ac3264515e4ac287d96c853b5c2efd763e13fea8689b9361b6d72L123-R128) [[2]](diffhunk://#diff-95932622b19ac3264515e4ac287d96c853b5c2efd763e13fea8689b9361b6d72L138-R144) [[3]](diffhunk://#diff-95932622b19ac3264515e4ac287d96c853b5c2efd763e13fea8689b9361b6d72R160-R187) [[4]](diffhunk://#diff-b7e9159481dd9d813e444c45b1a28ca0e5d0da11b26dacf3bad8eea04a31d9d7R172-R173) [[5]](diffhunk://#diff-b7e9159481dd9d813e444c45b1a28ca0e5d0da11b26dacf3bad8eea04a31d9d7R4) [[6]](diffhunk://#diff-05a44650028cfb1baf6ca4724c08d266e329f1cb350a75d69d62a9a78901cc32L32-R35)

- The `LaunchAndInject` function now kills lingering `EADesktop.exe`, `Origin.exe`, and (for GW2) `steam.exe` processes before launching the game, to ensure launch arguments are read properly.
- The function now accepts parameters for the DLL name, mod data path, and GW2 flag, and sets the `GAME_DATA_DIR` environment variable if mod data is enabled, improving mod support. [[1]](diffhunk://#diff-d2b9760368ff0524c2c3c4df67afbb9ed6627a25fa39eba3846018b4b6f8d349L268-R276) [[2]](diffhunk://#diff-95932622b19ac3264515e4ac287d96c853b5c2efd763e13fea8689b9361b6d72R279-R312) [[3]](diffhunk://#diff-95932622b19ac3264515e4ac287d96c853b5c2efd763e13fea8689b9361b6d72R323-R328) [[4]](diffhunk://#diff-05a44650028cfb1baf6ca4724c08d266e329f1cb350a75d69d62a9a78901cc32L32-R35)

- The UI now passes the selected mod data path and GW2 flag to the launcher logic, and the argument builder no longer appends the `-dataPath` argument directly, instead relying on the environment variable. [[1]](diffhunk://#diff-d2b9760368ff0524c2c3c4df67afbb9ed6627a25fa39eba3846018b4b6f8d349L268-R276) [[2]](diffhunk://#diff-95932622b19ac3264515e4ac287d96c853b5c2efd763e13fea8689b9361b6d72L107-L113)

- Added a generic `KillProcessByName` utility for process cleanup, and included additional headers for process enumeration. [[1]](diffhunk://#diff-95932622b19ac3264515e4ac287d96c853b5c2efd763e13fea8689b9361b6d72R236-R270) [[2]](diffhunk://#diff-95932622b19ac3264515e4ac287d96c853b5c2efd763e13fea8689b9361b6d72R5-R11)