### PR TITLE
Fix GW1 mods not being loaded

### DIFF
--- a/Launcher/assets/app.manifest
+++ b/Launcher/assets/app.manifest
@@ -4,7 +4,7 @@
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>
-        <requestedExecutionLevel level="requireAdministrator" uiAccess="false"/>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
       </requestedPrivileges>
     </security>
   </trustInfo>


### PR DESCRIPTION
Changed the `requestedExecutionLevel` in `Launcher/assets/app.manifest` from `requireAdministrator` to `asInvoker`, so the launcher no longer requires admin privileges to run. 7 hours of debugging just for one line 😭