### PR TITLE
Add - gameSelect buttons to the patcher tab

### DIFF
--- a/Launcher/src/config/Config.hpp
+++ b/Launcher/src/config/Config.hpp
@@ -22,6 +22,7 @@ struct Config {
     std::string password;
 
     std::string game_selected = "gw1";
+    std::string patch_selected = "gw1";
     bool launch_directly = false;
 
     ImVec4 baseColor = ImVec4(0.25f, 0.47f, 0.32f, 1.0f);
@@ -59,6 +60,18 @@ struct Config {
         if (val == 1) game_selected = "gw2";
         else if (val == 2) game_selected = "bfn";
         else game_selected = "gw1";
+    }
+
+    int get_patch_selected_int() const {
+        if (patch_selected == "gw2") return 1;
+        if (patch_selected == "bfn") return 2;
+        return 0;
+    }
+
+    void set_patch_selected_from_int(int val) {
+        if (val == 1) patch_selected = "gw2";
+        else if (val == 2) patch_selected = "bfn";
+        else patch_selected = "gw1";
     }
 };
 

--- a/Launcher/src/ui/Ui.cpp
+++ b/Launcher/src/ui/Ui.cpp
@@ -282,6 +282,13 @@ static void drawPatcherTab(HWND hwnd, float dpiScale) {
 
 	int gameSelectedInt = g_config.get_game_selected_int();
 
+	ImGui::SetCursorPosX(centerOffset);
+	if (ImGui::RadioButton("GW1", &gameSelectedInt, GAME_GW1)) g_config.set_game_selected_from_int(GAME_GW1);
+	ImGui::SameLine(0.0f, 40 * dpiScale);
+	if (ImGui::RadioButton("GW2", &gameSelectedInt, GAME_GW2)) g_config.set_game_selected_from_int(GAME_GW2);
+	ImGui::SameLine(0.0f, 40 * dpiScale);
+	if (ImGui::RadioButton("BFN", &gameSelectedInt, GAME_BFN)) g_config.set_game_selected_from_int(GAME_BFN);
+
 	fs::path launcherDir = fs::path([] {
 		char path[MAX_PATH];
 		GetModuleFileNameA(NULL, path, MAX_PATH);

--- a/Launcher/src/ui/Ui.cpp
+++ b/Launcher/src/ui/Ui.cpp
@@ -280,14 +280,14 @@ static void drawPatcherTab(HWND hwnd, float dpiScale) {
 	float fieldWidth = safeWidth * 0.85f;
 	float centerOffset = (safeWidth - fieldWidth) / 2.0f;
 
-	int gameSelectedInt = g_config.get_game_selected_int();
+	int gameSelectedInt = g_config.get_patch_selected_int();
 
 	ImGui::SetCursorPosX(centerOffset);
-	if (ImGui::RadioButton("GW1", &gameSelectedInt, GAME_GW1)) g_config.set_game_selected_from_int(GAME_GW1);
+	if (ImGui::RadioButton("GW1", &gameSelectedInt, GAME_GW1)) g_config.set_patch_selected_from_int(GAME_GW1);
 	ImGui::SameLine(0.0f, 40 * dpiScale);
-	if (ImGui::RadioButton("GW2", &gameSelectedInt, GAME_GW2)) g_config.set_game_selected_from_int(GAME_GW2);
+	if (ImGui::RadioButton("GW2", &gameSelectedInt, GAME_GW2)) g_config.set_patch_selected_from_int(GAME_GW2);
 	ImGui::SameLine(0.0f, 40 * dpiScale);
-	if (ImGui::RadioButton("BFN", &gameSelectedInt, GAME_BFN)) g_config.set_game_selected_from_int(GAME_BFN);
+	if (ImGui::RadioButton("BFN", &gameSelectedInt, GAME_BFN)) g_config.set_patch_selected_from_int(GAME_BFN);
 
 	fs::path launcherDir = fs::path([] {
 		char path[MAX_PATH];


### PR DESCRIPTION
Added the Game Select buttons to the patcher tab, which work separately from the launcher tab as the video below shows.

https://github.com/user-attachments/assets/8a251206-33d5-4e7e-a58a-dae7e86ae8d1

